### PR TITLE
Fix the transcribeFile function to remove 30 seconds limit

### DIFF
--- a/app/src/main/java/com/whispertflite/asr/Recorder.java
+++ b/app/src/main/java/com/whispertflite/asr/Recorder.java
@@ -22,6 +22,7 @@ public class Recorder {
     public static final String ACTION_RECORD = "Record";
     public static final String MSG_RECORDING = "Recording...";
     public static final String MSG_RECORDING_DONE = "Recording done...!";
+    public static final int RECORDING_DURATION = 60; //60 seconds
 
     private final Context mContext;
     private final AtomicBoolean mInProgress = new AtomicBoolean(false);
@@ -103,7 +104,7 @@ public class Recorder {
             audioRecord.startRecording();
 
             int bufferSize1Sec = sampleRateInHz * bytesPerSample * channels;
-            int bufferSize30Sec = bufferSize1Sec * 30;
+            int bufferSize30Sec = bufferSize1Sec * RECORDING_DURATION;
             ByteBuffer buffer30Sec = ByteBuffer.allocateDirect(bufferSize30Sec);
             ByteBuffer bufferRealtime = ByteBuffer.allocateDirect(bufferSize1Sec * 5);
 


### PR DESCRIPTION
Adjust the recorder to record for 60 seconds and fix the native `transcribeFile` function to support transcribing files of any size. 

I've tested with files that are 60 seconds long.