### PR TITLE
Fix: reset g_whisper_tflite and g_vocab on freeModel() to avoid crashes when switching between models

### DIFF
--- a/whisper_native/app/src/main/cpp/TFLiteEngine.cpp
+++ b/whisper_native/app/src/main/cpp/TFLiteEngine.cpp
@@ -84,7 +84,7 @@ int TFLiteEngine:: loadModel(const char *modelPath, const bool isMultilingual) {
         }
 
         // add additional vocab ids
-        int n_vocab_additional = 51864; 
+        int n_vocab_additional = 51864;
         if (isMultilingual) {
             n_vocab_additional = 51865;
             g_vocab.token_eot++;
@@ -213,7 +213,7 @@ std::string TFLiteEngine::transcribeBuffer(std::vector<float> samples) {
         if (output_int[i] == g_vocab.token_eot) {
             break;
         }
-        
+
         if (output_int[i] < g_vocab.token_eot) {
             text += whisper_token_to_str(output_int[i]);
         }
@@ -244,7 +244,7 @@ void TFLiteEngine::freeModel() {
     }
 
     // Set the flag to false to avoid issues in the re-initialization of the model
-    if(g_whisper_tflite.is_whisper_tflite_initialized){
+    if (g_whisper_tflite.is_whisper_tflite_initialized) {
         g_whisper_tflite.is_whisper_tflite_initialized = false;
     }
 

--- a/whisper_native/app/src/main/cpp/TFLiteEngine.cpp
+++ b/whisper_native/app/src/main/cpp/TFLiteEngine.cpp
@@ -243,5 +243,13 @@ void TFLiteEngine::freeModel() {
         delete[] g_whisper_tflite.buffer;
     }
 
+    // Set the flag to false to avoid issues in the re-initialization of the model
+    if(g_whisper_tflite.is_whisper_tflite_initialized){
+        g_whisper_tflite.is_whisper_tflite_initialized = false;
+    }
+
+    // Reset the whisper_vocab structure to clear the vocab data
+    g_vocab.reset();
+
     std::cout << "Exiting " << __func__ << "()" << std::endl;
 }

--- a/whisper_native/app/src/main/cpp/whisper.h
+++ b/whisper_native/app/src/main/cpp/whisper.h
@@ -43,6 +43,18 @@ struct whisper_vocab {
 
     static const int token_translwordate = 50358;
     static const int token_transcribe = 50359;
+
+    // Reset the whisper_vocab structure
+    void reset() {
+        id_to_token.clear();
+        n_vocab_additional = 51864;
+        token_eot = 50256;
+        token_sot = 50257;
+        token_prev = 50360;
+        token_solm = 50361;
+        token_not = 50362;
+        token_beg = 50363;
+    }
 };
 
 // Global whisper_vocab instance


### PR DESCRIPTION
On the whisper_native project, there is a bug that causes the app to crash because of a null pointer exception when you switch between the models.
### Steps to reproduce

1. Run the `whisper_native` project
2. Select any input file from the available ones (I used jfk.wav)
3. Click on `Transcribe` button, which works as expected.
4. Click on the models spinner and select another model from the models available, and the click on `Transcribe` again; the app will crash.

### Issue Explanation
When you select on new model, the app calls `freeModel` function from Java to the native side; this function is not resetting all the needed fields, and particularly the `is_whisper_tflite_initialized` on the `g_whisper_tflite` struct. `is_whisper_tflite_initialized` should be set to false, so when `loadModel` function is called, the `if (!g_whisper_tflite.is_whisper_tflite_initialized)` check will be true, and the initialization will carry on normally. Additionally, the `g_vocab` should also be reset especially when using the multi-lingual model; otherwise, we will be using the same struct input on a new session, and this will cause the transcribe functionality to return random/inaccurate results.